### PR TITLE
fix cdn references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ If you wish to use it as a jQuery plugin, make sure you import jQuery as well.
 ### Over CDN
 
 ```
-<script type="text/javascript" src="https://unpkg.com/browse/youtube-background@1.0.10/jquery.youtube-background.js"></script>
+<script type="text/javascript" src="https://unpkg.com/youtube-background/jquery.youtube-background.js"></script>
 ```
 or minified:
 ```
-<script type="text/javascript" src="https://unpkg.com/browse/youtube-background@1.0.10/jquery.youtube-background.min.js"></script>
+<script type="text/javascript" src="https://unpkg.com/youtube-background/jquery.youtube-background.min.js"></script>
 ```
 
 ## Usage


### PR DESCRIPTION
In the examples for loading the script from CDN, the URLs were pointing to the `browse` repo view rather than the actual script files. This updates them to the actual sources. It also removes the version number so that the latest version is always used.

Previous 'browse' URL with version:  https://unpkg.com/browse/youtube-background@1.0.10/jquery.youtube-background.js

New URL without 'browse' & without version:  https://unpkg.com/youtube-background/jquery.youtube-background.js